### PR TITLE
Mecanum wheel is now working

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
@@ -3,6 +3,8 @@ package org.firstinspires.ftc.teamcode;
 import com.qualcomm.robotcore.hardware.DcMotor;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
+import org.firstinspires.ftc.robotcore.external.Telemetry;
+
 class MecanumDrive {
     private DcMotor frontLeft;
     private DcMotor frontRight;
@@ -33,11 +35,15 @@ class MecanumDrive {
         backRight.setPower(brSpeed / largest);
     }
 
-    void driveMecanum(double forward, double strafe, double rotate) {
+    void driveMecanum(Telemetry telemetry, double forward, double strafe, double rotate) {
         double frontLeftSpeed = forward + strafe + rotate;
         double frontRightSpeed = forward - strafe - rotate;
         double backLeftSpeed = forward - strafe + rotate;
         double backRightSpeed = forward + strafe - rotate;
+        telemetry.addData("front left", frontLeftSpeed);
+        telemetry.addData("front right", frontRightSpeed);
+        telemetry.addData("back left", backLeftSpeed);
+        telemetry.addData("back right", backRightSpeed);
 
         setSpeeds(frontLeftSpeed, frontRightSpeed, backLeftSpeed, backRightSpeed);
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
@@ -21,10 +21,25 @@ class MecanumDrive {
     }
 
     void setSpeeds(double flSpeed, double frSpeed, double blSpeed, double brSpeed) {
-        frontLeft.setPower(flSpeed);
-        frontRight.setPower(frSpeed);
-        backLeft.setPower(blSpeed);
-        backRight.setPower(brSpeed);
+        double largest = 1.0;
+        largest = Math.max(largest, Math.abs(flSpeed));
+        largest = Math.max(largest, Math.abs(frSpeed));
+        largest = Math.max(largest, Math.abs(blSpeed));
+        largest = Math.max(largest, Math.abs(brSpeed));
+
+        frontLeft.setPower(flSpeed / largest);
+        frontRight.setPower(frSpeed / largest);
+        backLeft.setPower(blSpeed / largest);
+        backRight.setPower(brSpeed / largest);
+    }
+
+    void driveMecanum(double forward, double strafe, double rotate) {
+        double frontLeftSpeed = strafe + forward + rotate;
+        double frontRightSpeed = strafe - forward - rotate;
+        double backLeftSpeed = strafe - forward + rotate;
+        double backRightSpeed = strafe + forward - rotate;
+
+        setSpeeds(frontLeftSpeed, frontRightSpeed, backLeftSpeed, backRightSpeed);
 
 
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
@@ -39,15 +39,11 @@ class MecanumDrive {
         backRight.setPower(brSpeed / largest);
     }
 
-    void driveMecanum(Telemetry telemetry, double forward, double strafe, double rotate) {
+    void driveMecanum(double forward, double strafe, double rotate) {
         double frontLeftSpeed = forward + strafe + rotate;
         double frontRightSpeed = forward - strafe - rotate;
         double backLeftSpeed = forward - strafe + rotate;
         double backRightSpeed = forward + strafe - rotate;
-        telemetry.addData("front left", frontLeftSpeed);
-        telemetry.addData("front right", frontRightSpeed);
-        telemetry.addData("back left", backLeftSpeed);
-        telemetry.addData("back right", backRightSpeed);
 
         setSpeeds(frontLeftSpeed, frontRightSpeed, backLeftSpeed, backRightSpeed);
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
@@ -34,10 +34,10 @@ class MecanumDrive {
     }
 
     void driveMecanum(double forward, double strafe, double rotate) {
-        double frontLeftSpeed = strafe + forward + rotate;
-        double frontRightSpeed = strafe - forward - rotate;
-        double backLeftSpeed = strafe - forward + rotate;
-        double backRightSpeed = strafe + forward - rotate;
+        double frontLeftSpeed = forward + strafe + rotate;
+        double frontRightSpeed = forward - strafe - rotate;
+        double backLeftSpeed = forward - strafe + rotate;
+        double backRightSpeed = forward + strafe - rotate;
 
         setSpeeds(frontLeftSpeed, frontRightSpeed, backLeftSpeed, backRightSpeed);
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
@@ -1,0 +1,31 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.HardwareMap;
+
+class MecanumDrive {
+    private DcMotor frontLeft;
+    private DcMotor frontRight;
+    private DcMotor backRight;
+    private DcMotor backLeft;
+
+    void init(HardwareMap hwMap) {
+        frontLeft = hwMap.get(DcMotor.class, "front_left");
+        frontLeft.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        frontRight = hwMap.get(DcMotor.class, "front_right");
+        frontRight.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        backLeft = hwMap.get(DcMotor.class, "back_left");
+        backLeft.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+        backRight = hwMap.get(DcMotor.class, "back_right");
+        backRight.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+    }
+
+    void setSpeeds(double flSpeed, double frSpeed, double blSpeed, double brSpeed) {
+        frontLeft.setPower(flSpeed);
+        frontRight.setPower(frSpeed);
+        backLeft.setPower(blSpeed);
+        backRight.setPower(brSpeed);
+
+
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrive.java
@@ -1,6 +1,7 @@
 package org.firstinspires.ftc.teamcode;
 
 import com.qualcomm.robotcore.hardware.DcMotor;
+import com.qualcomm.robotcore.hardware.DcMotorSimple;
 import com.qualcomm.robotcore.hardware.HardwareMap;
 
 import org.firstinspires.ftc.robotcore.external.Telemetry;
@@ -20,6 +21,9 @@ class MecanumDrive {
         backLeft.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
         backRight = hwMap.get(DcMotor.class, "back_right");
         backRight.setMode(DcMotor.RunMode.RUN_USING_ENCODER);
+
+        backRight.setDirection(DcMotorSimple.Direction.REVERSE);
+        frontRight.setDirection(DcMotorSimple.Direction.REVERSE);
     }
 
     void setSpeeds(double flSpeed, double frSpeed, double blSpeed, double brSpeed) {
@@ -46,6 +50,16 @@ class MecanumDrive {
         telemetry.addData("back right", backRightSpeed);
 
         setSpeeds(frontLeftSpeed, frontRightSpeed, backLeftSpeed, backRightSpeed);
+
+
+    }
+
+    void reportEncoders(Telemetry telemetry) {
+        telemetry.addData("Encoders", "%d %d %d %d",
+                frontLeft.getCurrentPosition(),
+                frontRight.getCurrentPosition(),
+                backLeft.getCurrentPosition(),
+                backRight.getCurrentPosition());
 
 
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrivingOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrivingOpMode.java
@@ -23,7 +23,7 @@ public class MecanumDrivingOpMode extends OpMode {
         double strafe = gamepad1.left_stick_x;
         double rotate = gamepad1.right_stick_x;
 
-        mecanumDrive.driveMecanum(telemetry, forward, strafe, rotate);
+        mecanumDrive.driveMecanum(forward, strafe, rotate);
 
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrivingOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrivingOpMode.java
@@ -1,0 +1,29 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+
+
+@TeleOp()
+@Disabled
+public class MecanumDrivingOpMode extends OpMode {
+    private MecanumDrive mecanumDrive = new MecanumDrive();
+
+    // Code to run ONCE when the driver hits INIT
+    @Override
+    public void init() {
+        mecanumDrive.init(hardwareMap);
+    }
+
+    // Code to run REPEATEDLY after the driver hits PLAY but before they hit STOP
+    @Override
+    public void loop() {
+        double forward = gamepad1.left_stick_y * -1; //The y direction on the gamepad is reversed idk why
+        double strafe = gamepad1.left_stick_x;
+        double rotate = gamepad1.right_stick_x;
+
+        mecanumDrive.driveMecanum(forward, strafe, rotate);
+
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrivingOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/MecanumDrivingOpMode.java
@@ -6,7 +6,7 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
 
 @TeleOp()
-@Disabled
+//@Disabled
 public class MecanumDrivingOpMode extends OpMode {
     private MecanumDrive mecanumDrive = new MecanumDrive();
 

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/SlowerMecanumDrivingOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/SlowerMecanumDrivingOpMode.java
@@ -24,5 +24,6 @@ public class SlowerMecanumDrivingOpMode extends OpMode {
 
         mecanumDrive.driveMecanum(telemetry, forward / 4, strafe / 4, rotate / 4);
 
+        mecanumDrive.reportEncoders(telemetry);
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/SlowerMecanumDrivingOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/SlowerMecanumDrivingOpMode.java
@@ -1,13 +1,12 @@
 package org.firstinspires.ftc.teamcode;
 
-import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
 
 @TeleOp()
 //@Disabled
-public class MecanumDrivingOpMode extends OpMode {
+public class SlowerMecanumDrivingOpMode extends OpMode {
     private MecanumDrive mecanumDrive = new MecanumDrive();
 
     // Code to run ONCE when the driver hits INIT
@@ -23,7 +22,7 @@ public class MecanumDrivingOpMode extends OpMode {
         double strafe = gamepad1.left_stick_x;
         double rotate = gamepad1.right_stick_x;
 
-        mecanumDrive.driveMecanum(telemetry, forward, strafe, rotate);
+        mecanumDrive.driveMecanum(telemetry, forward / 4, strafe / 4, rotate / 4);
 
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/SlowerMecanumDrivingOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/SlowerMecanumDrivingOpMode.java
@@ -22,7 +22,7 @@ public class SlowerMecanumDrivingOpMode extends OpMode {
         double strafe = gamepad1.left_stick_x;
         double rotate = gamepad1.right_stick_x;
 
-        mecanumDrive.driveMecanum(telemetry, forward / 4, strafe / 4, rotate / 4);
+        mecanumDrive.driveMecanum(forward / 4, strafe / 4, rotate / 4);
 
         mecanumDrive.reportEncoders(telemetry);
     }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TestWiring.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TestWiring.java
@@ -1,0 +1,41 @@
+package org.firstinspires.ftc.teamcode;
+
+import com.qualcomm.robotcore.eventloop.opmode.Disabled;
+import com.qualcomm.robotcore.eventloop.opmode.OpMode;
+import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
+import com.qualcomm.robotcore.robot.Robot;
+
+
+@TeleOp()
+@Disabled
+public class TestWiring extends OpMode {
+    private MecanumDrive MecanumDrive = new MecanumDrive();
+
+    // Code to run ONCE when the driver hits INIT
+    @Override
+    public void init() {
+
+    }
+
+    // Code to run REPEATEDLY after the driver hits PLAY but before they hit STOP
+    @Override
+    public void loop() {
+
+        if (gamepad1.left_bumper) {
+            MecanumDrive.setSpeeds(1, 0, 0, 0);
+
+        }
+        if (gamepad1.right_bumper) {
+            MecanumDrive.setSpeeds(0, 1, 0, 0);
+
+        }
+        if (gamepad1.left_trigger > 0.0) {
+            MecanumDrive.setSpeeds(0, 0, 1, 0);
+
+        }
+        if (gamepad1.right_trigger > 0.0) {
+            MecanumDrive.setSpeeds(0, 0, 0, 1);
+
+        }
+    }
+}

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TestWiringOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TestWiringOpMode.java
@@ -6,7 +6,7 @@ import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
 
 
 @TeleOp()
-@Disabled
+//@Disabled
 public class TestWiringOpMode extends OpMode {
     private MecanumDrive mecanumDrive = new MecanumDrive();
 
@@ -23,18 +23,16 @@ public class TestWiringOpMode extends OpMode {
         if (gamepad1.left_bumper) {
             mecanumDrive.setSpeeds(1, 0, 0, 0);
 
-        }
-        if (gamepad1.right_bumper) {
+        } else if (gamepad1.right_bumper) {
             mecanumDrive.setSpeeds(0, 1, 0, 0);
-
-        }
-        if (gamepad1.left_trigger > 0.0) {
+        } else if (gamepad1.left_trigger > 0.0) {
             mecanumDrive.setSpeeds(0, 0, 1, 0);
 
-        }
-        if (gamepad1.right_trigger > 0.0) {
+        } else if (gamepad1.right_trigger > 0.0) {
             mecanumDrive.setSpeeds(0, 0, 0, 1);
 
+        } else {
+            mecanumDrive.setSpeeds(0, 0, 0, 0);
         }
     }
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TestWiringOpMode.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/TestWiringOpMode.java
@@ -3,18 +3,17 @@ package org.firstinspires.ftc.teamcode;
 import com.qualcomm.robotcore.eventloop.opmode.Disabled;
 import com.qualcomm.robotcore.eventloop.opmode.OpMode;
 import com.qualcomm.robotcore.eventloop.opmode.TeleOp;
-import com.qualcomm.robotcore.robot.Robot;
 
 
 @TeleOp()
 @Disabled
-public class TestWiring extends OpMode {
-    private MecanumDrive MecanumDrive = new MecanumDrive();
+public class TestWiringOpMode extends OpMode {
+    private MecanumDrive mecanumDrive = new MecanumDrive();
 
     // Code to run ONCE when the driver hits INIT
     @Override
     public void init() {
-
+        mecanumDrive.init(hardwareMap);
     }
 
     // Code to run REPEATEDLY after the driver hits PLAY but before they hit STOP
@@ -22,19 +21,19 @@ public class TestWiring extends OpMode {
     public void loop() {
 
         if (gamepad1.left_bumper) {
-            MecanumDrive.setSpeeds(1, 0, 0, 0);
+            mecanumDrive.setSpeeds(1, 0, 0, 0);
 
         }
         if (gamepad1.right_bumper) {
-            MecanumDrive.setSpeeds(0, 1, 0, 0);
+            mecanumDrive.setSpeeds(0, 1, 0, 0);
 
         }
         if (gamepad1.left_trigger > 0.0) {
-            MecanumDrive.setSpeeds(0, 0, 1, 0);
+            mecanumDrive.setSpeeds(0, 0, 1, 0);
 
         }
         if (gamepad1.right_trigger > 0.0) {
-            MecanumDrive.setSpeeds(0, 0, 0, 1);
+            mecanumDrive.setSpeeds(0, 0, 0, 1);
 
         }
     }


### PR DESCRIPTION
Right side mecanum wheels had encoder values that were negative. Wires were connected to opposite wires instead of corresponding colored wires. Also, reversed right side motors to solve the problem.
