### PR TITLE
Had to change the versions back to what came from FTC

### DIFF
--- a/build.common.gradle
+++ b/build.common.gradle
@@ -21,7 +21,7 @@ apply plugin: 'com.android.application'
 
 android {
 
-    compileSdkVersion 26
+    compileSdkVersion 23
 
     signingConfigs {
         debug {
@@ -39,7 +39,7 @@ android {
     defaultConfig {
         applicationId 'com.qualcomm.ftcrobotcontroller'
         minSdkVersion 19
-        targetSdkVersion 26
+        targetSdkVersion 19
 
         /**
          * We keep the versionCode and versionName of robot controller applications in sync with


### PR DESCRIPTION
Details on why are here:
https://stackoverflow.com/questions/35767923/caused-by-java-lang-illegalstateexception-unable-to-create-directory-in-androi

Before issuing a pull request, please see the contributing page.
