### PR TITLE
How to handle licenses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# license file
+TeamCode/src/main/res/values/license.xml
+
 # built application files
 *.apk
 *.ap_

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/licenses.xml.template
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/licenses.xml.template
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?><!-- This needs to be copied into the res/values directory as licenses.xml with your licenses in it -->
+<resources>
+    <string name="vuforiaLicense">--- VUFORIA LICENSE KEY GOES HERE ---</string>
+</resources>


### PR DESCRIPTION
There are licenses that we shouldn't expose in GitHub.
This has .gitignore where it won't put licenses.xml in git.
It has a licenses.xml.template in the main code location so everyone can see the format needed as well as where they belong.

